### PR TITLE
Update verified permissions service extension to use shared credentials

### DIFF
--- a/amazon-verfied-permissions/amazon-verified-permissions.go
+++ b/amazon-verfied-permissions/amazon-verified-permissions.go
@@ -13,10 +13,9 @@ import (
 	"time"
 
 	"maverics/app"
+	"maverics/aws/config"
+	v4 "maverics/aws/signer/v4"
 	"maverics/session"
-
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 // The following values should be updated for your environment.


### PR DESCRIPTION
Here's the changes required to use AWS shared credentials instead of the IAM credentials directly.  There's an update required on the orchestrator before this gets merged in.